### PR TITLE
Move flow conservation demo and resize

### DIFF
--- a/front/public/index.html
+++ b/front/public/index.html
@@ -22,8 +22,6 @@
 </head>
 
 <body>
-  <div id="flowConservationContainer">
-    <svg id="flowConservationSVG"></svg>
-  </div>
+  
 </body>
 </html>

--- a/front/src/App.svelte
+++ b/front/src/App.svelte
@@ -1290,10 +1290,10 @@
       </div>
 
     
-    <div id="flowConservationContainer">
-      <svg id="flowConservationSVG"></svg>
+    <div id="flowConservationContainer" style="max-width:700px;margin:20px auto;">
+      <svg id="flowConservationSVG" style="width:100%;height:auto;"></svg>
     </div>
-    <script src="/static/flow_conservation.js">
+    <script src="flow_conservation.js">
       particlesJS("particles-js", {
   particles: {
     number: { value: 30, density: { enable: true, value_area: 600 } },


### PR DESCRIPTION
## Summary
- remove duplicate flow conservation container from `index.html`
- resize flow conservation demo and load script with relative path

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686e8710ad8c832c9ddc80b091cdcebe