### PR TITLE
Move flow conservation demo below Tetris board

### DIFF
--- a/front/public/index.html
+++ b/front/public/index.html
@@ -22,8 +22,6 @@
 </head>
 
 <body>
-  <div id="flowConservationContainer">
-    <svg id="flowConservationSVG"></svg>
-  </div>
+  
 </body>
 </html>

--- a/front/src/App.svelte
+++ b/front/src/App.svelte
@@ -1261,7 +1261,8 @@
     </section>
     <div class="A_centerwrap">
       <div class="A_tetriscontainer">
-        <div class="A_board">
+        <div class="A_board-column">
+          <div class="A_board">
           <!-- 1) Background canvas (will be painted with Viridis) -->
           <canvas
             id="tetrisBgCanvas"
@@ -1277,6 +1278,11 @@
             height="600"
             style="position: absolute; top: 0; left: 0; z-index: 1;"
           ></canvas>
+          </div>
+
+          <div id="flowConservationContainer" style="max-width:300px;margin:20px auto;">
+            <svg id="flowConservationSVG" style="width:100%;height:auto;"></svg>
+          </div>
         </div>
 
         <div class="A_sidebar">
@@ -1290,10 +1296,7 @@
       </div>
 
     
-    <div id="flowConservationContainer">
-      <svg id="flowConservationSVG"></svg>
-    </div>
-    <script src="/static/flow_conservation.js">
+    <script src="flow_conservation.js">
       particlesJS("particles-js", {
   particles: {
     number: { value: 30, density: { enable: true, value_area: 600 } },

--- a/front/src/styles.css
+++ b/front/src/styles.css
@@ -545,6 +545,13 @@ input[type="range"] {
   padding: 20px;
 }
 
+.A_board-column {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 300px;
+}
+
 .A_board {
   position: relative;
   width: 180px;


### PR DESCRIPTION
## Summary
- wrap Tetris board and flow demo in a column container
- add styles for the new `.A_board-column`
- resize the flow conservation demo and place it under the board

## Testing
- `npm run build` *(fails: rollup not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e8710ad8c832c9ddc80b091cdcebe