### PR TITLE
Fix flow conservation placement

### DIFF
--- a/front/src/App.svelte
+++ b/front/src/App.svelte
@@ -1280,9 +1280,6 @@
           ></canvas>
           </div>
 
-          <div id="flowConservationContainer" style="max-width:300px;margin:20px auto;">
-            <svg id="flowConservationSVG" style="width:100%;height:auto;"></svg>
-          </div>
         </div>
 
         <div class="A_sidebar">
@@ -1298,7 +1295,6 @@
     <div id="flowConservationContainer" style="max-width:700px;margin:20px auto;">
       <svg id="flowConservationSVG" style="width:100%;height:auto;"></svg>
     </div>
-
     <script src="flow_conservation.js">
       particlesJS("particles-js", {
   particles: {
@@ -1330,6 +1326,7 @@
         initFlowConservationDemo();
       });
     </script>
+
     </div>
 
     <section class="section">


### PR DESCRIPTION
## Summary
- reintroduce flow conservation scripts in App.svelte so the visualization initializes correctly

## Testing
- `npm run build` *(fails: rollup not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e8c734a20832c914f0bd67d00d83b