### PR TITLE
Fix flow demo initialization

### DIFF
--- a/front/src/App.svelte
+++ b/front/src/App.svelte
@@ -1036,6 +1036,12 @@
   //Title to display in tab
   document.title = "GFlowNet Playground";
 
+  onMount(() => {
+    if (typeof initFlowConservationDemo === 'function') {
+      initFlowConservationDemo();
+    }
+  });
+
 
   function A_maximizeMw() {
     A_molecule_prop.update((weights) => {
@@ -1295,39 +1301,6 @@
     <div id="flowConservationContainer" style="max-width:700px;margin:20px auto;">
       <svg id="flowConservationSVG" style="width:100%;height:auto;"></svg>
     </div>
-
-    <script src="flow_conservation.js">
-      particlesJS("particles-js", {
-  particles: {
-    number: { value: 30, density: { enable: true, value_area: 600 } },
-    color: { value: "#00bfff" },
-    shape: { type: "circle" },
-    opacity: { value: 0.4, random: true },
-    size: { value: 2, random: true },
-    line_linked: { enable: false },
-    move: {
-      enable: true,
-      speed: 1,
-      straight: true,
-      random: false,
-      out_mode: "out"
-    }
-  },
-  interactivity: {
-    detect_on: "canvas",
-    events: { onhover: { enable: false }, onclick: { enable: false } }
-  },
-  retina_detect: false
-});
-
-
-    </script>
-    <script>
-      document.addEventListener("DOMContentLoaded", function() {
-        initFlowConservationDemo();
-      });
-    </script>
-=======
 
 
     </div>


### PR DESCRIPTION
## Summary
- remove stray inline scripts and merge artifact
- call `initFlowConservationDemo` when the Svelte app mounts so the flow demo is ready for Tetris updates

## Testing
- `npm run build` *(fails: rollup not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e937429a4832cac1d7234022c4a61