### PR TITLE
Fix flow demo loading order

### DIFF
--- a/front/public/index.html
+++ b/front/public/index.html
@@ -11,17 +11,17 @@
 	<link rel='stylesheet' href='/build/bundle.css'>
 
 	<script defer src='/build/bundle.js'></script>
-        <script src="Tetris.js"></script>
+        <script defer src="Tetris.js"></script>
 
 
-        <script src="/flow_conservation.js"></script>
+        <script defer src="/flow_conservation.js"></script>
         <script src="https://cdn.jsdelivr.net/npm/onnxruntime-web/dist/ort.min.js"></script>
         <script src="https://d3js.org/d3.v7.min.js"></script>
         <script src="https://unpkg.com/d3-sankey@0.12.3/dist/d3-sankey.min.js"></script>
         <script src="https://cdn.jsdelivr.net/npm/particles.js@2.0.0/particles.min.js"></script>
         <script src="https://cdn.jsdelivr.net/npm/@rdkit/rdkit@2025.3.2-1.0.0/dist/RDKit_minimal.js"></script>
 
-        <script src="flow_conservation.js"></script>
+        <script defer src="flow_conservation.js"></script>
 
         <script src="https://cdn.jsdelivr.net/npm/onnxruntime-web/dist/ort.min.js"></script>
         <script src="https://d3js.org/d3.v7.min.js"></script>


### PR DESCRIPTION
## Summary
- load Tetris.js and flow_conservation.js after DOMContentLoaded

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687164a939f4832cb8d731317ebb5977