### PR TITLE
Fix flow demo container insertion

### DIFF
--- a/front/public/flow_conservation.js
+++ b/front/public/flow_conservation.js
@@ -35,11 +35,15 @@
 
     let svg = d3.select('#flowConservationSVG');
     if (svg.empty()) {
-      // Attempt to create the container on the fly if it does not exist
       let container = d3.select('#flowConservationContainer');
       if (container.empty()) {
-        container = d3.select('body')
-          .append('div')
+        // Insert the container right before the "Domain application" heading if it exists
+        const domainHeading = Array.from(document.querySelectorAll('h2.section-title'))
+          .find(h => h.textContent.trim().toLowerCase().startsWith('domain application'));
+        const beforeEl = domainHeading || null;
+        const parent = beforeEl ? beforeEl.parentNode : document.body;
+        container = d3.select(parent)
+          .insert('div', beforeEl ? () => beforeEl : null)
           .attr('id', 'flowConservationContainer')
           .style('max-width', '700px')
           .style('margin', '20px auto');

--- a/front/public/index.html
+++ b/front/public/index.html
@@ -11,18 +11,10 @@
 	<link rel='stylesheet' href='/build/bundle.css'>
 
 	<script defer src='/build/bundle.js'></script>
-        <script src="Tetris.js"></script>
+        <script defer src="Tetris.js"></script>
 
 
-        <script src="/flow_conservation.js"></script>
-        <script src="https://cdn.jsdelivr.net/npm/onnxruntime-web/dist/ort.min.js"></script>
-        <script src="https://d3js.org/d3.v7.min.js"></script>
-        <script src="https://unpkg.com/d3-sankey@0.12.3/dist/d3-sankey.min.js"></script>
-        <script src="https://cdn.jsdelivr.net/npm/particles.js@2.0.0/particles.min.js"></script>
-        <script src="https://cdn.jsdelivr.net/npm/@rdkit/rdkit@2025.3.2-1.0.0/dist/RDKit_minimal.js"></script>
-
-        <script src="flow_conservation.js"></script>
-
+        <script defer src="/flow_conservation.js"></script>
         <script src="https://cdn.jsdelivr.net/npm/onnxruntime-web/dist/ort.min.js"></script>
         <script src="https://d3js.org/d3.v7.min.js"></script>
         <script src="https://unpkg.com/d3-sankey@0.12.3/dist/d3-sankey.min.js"></script>


### PR DESCRIPTION
## Summary
- ensure the flow demo container is inserted before the Domain application heading
- defer script loading so demo appears in the correct place
- clarify comment explaining container insertion logic

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687164a939f4832cb8d731317ebb5977