### PR TITLE
Fix scoring race on restart

### DIFF
--- a/front/public/Tetris.js
+++ b/front/public/Tetris.js
@@ -1743,6 +1743,8 @@ function doResetGame() {
     restartOverlay = null;
   }
   resetGameLogic();
+  // make sure a leftover inference doesn't block new scoring
+  scoringInProgress = false;
 
   // Clear visuals
   currentGameState = null;


### PR DESCRIPTION
## Summary
- reset `scoringInProgress` when restarting a game to avoid empty flow values

## Testing
- `npm test` *(fails: Could not read package.json)*
- `(cd front && npm test)` *(fails: Missing script: "test")*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687265ff1d80832c9d5e3a115e5a7b1e