### PR TITLE
Add RL comparison fold-out

### DIFF
--- a/front/public/index.html
+++ b/front/public/index.html
@@ -15,6 +15,7 @@
 
 
         <script defer src="/flow_conservation.js"></script>
+        <script defer src="/comparison.js"></script>
 
         <script src="https://cdn.jsdelivr.net/npm/onnxruntime-web/dist/ort.min.js"></script>
         <script src="https://d3js.org/d3.v7.min.js"></script>

--- a/front/src/App.svelte
+++ b/front/src/App.svelte
@@ -1040,6 +1040,9 @@
     if (typeof initFlowConservationDemo === 'function') {
       initFlowConservationDemo();
     }
+    if (typeof initComparisonChart === 'function') {
+      initComparisonChart();
+    }
   });
 
 
@@ -1170,6 +1173,26 @@
         We also provide a <b>Playground</b> for experimenting with GFlowNet training.
         It provides an interactive environment to explore how GFlowNets adapt to changes in both reward functions and training hyperparameters.
       </p>
+    </section>
+
+    <section class="section">
+      <div class="image-container">
+        <Accordion>
+          <Panel color="secondary">
+            <Header>Comparison to reinforcement learning</Header>
+            <Content>
+              <p class="section-text">
+                A traditional reinforcement learning agent tends to focus its probability mass on
+                a single best trajectory. A GFlowNet instead distributes flow across many promising
+                paths. The animation below, generated with <code>comparison.js</code>, illustrates
+                this difference: the left graph shows a single-path RL policy, while the right graph
+                highlights how flow in a GFlowNet covers several alternatives.
+              </p>
+              <div id="comparisonChart" style="margin:20px auto; max-width:600px;"></div>
+            </Content>
+          </Panel>
+        </Accordion>
+      </div>
     </section>
 
 


### PR DESCRIPTION
## Summary
- load comparison.js on the webpage
- initialize comparison chart on mount
- add fold-out section comparing GFlowNets to RL before the core concepts section

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_687b81ab01a4832c9732e92cf4930fae