### PR TITLE
Fix deferred comparison chart

### DIFF
--- a/front/public/comparison.js
+++ b/front/public/comparison.js
@@ -178,3 +178,4 @@ defs.append("marker")
     return edges;
   }
 }
+window.initComparisonChart = initComparisonChart;

--- a/front/src/App.svelte
+++ b/front/src/App.svelte
@@ -1040,8 +1040,15 @@
     if (typeof initFlowConservationDemo === 'function') {
       initFlowConservationDemo();
     }
-    if (typeof initComparisonChart === 'function') {
-      initComparisonChart();
+    const tryInitComparison = () => {
+      if (typeof initComparisonChart === 'function') {
+        initComparisonChart();
+      }
+    };
+    if (document.readyState === 'complete') {
+      tryInitComparison();
+    } else {
+      window.addEventListener('load', tryInitComparison, { once: true });
     }
   });
 


### PR DESCRIPTION
## Summary
- initialize comparison chart after all scripts load
- expose `initComparisonChart` globally for Svelte

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687b89cdc504832ca2de1071691be78f