### PR TITLE
Fix deferred comparison chart

### DIFF
--- a/front/public/comparison.js
+++ b/front/public/comparison.js
@@ -1,4 +1,5 @@
 function initComparisonChart() {
+  console.log('comparison.js: initComparisonChart running');
   const container = d3.select("#comparisonChart");
   const width = 300, height = 400;
 
@@ -178,3 +179,4 @@ defs.append("marker")
     return edges;
   }
 }
+window.initComparisonChart = initComparisonChart;

--- a/front/public/index.html
+++ b/front/public/index.html
@@ -23,6 +23,15 @@
         <script src="https://cdn.jsdelivr.net/npm/particles.js@2.0.0/particles.min.js"></script>
         <script src="https://cdn.jsdelivr.net/npm/@rdkit/rdkit@2025.3.2-1.0.0/dist/RDKit_minimal.js"></script>
 
+        <script>
+          window.addEventListener('load', () => {
+            if (typeof initComparisonChart === 'function') {
+              console.log('Initializing comparison chart');
+              initComparisonChart();
+            }
+          });
+        </script>
+
 
 </head>
 

--- a/front/src/App.svelte
+++ b/front/src/App.svelte
@@ -1040,8 +1040,15 @@
     if (typeof initFlowConservationDemo === 'function') {
       initFlowConservationDemo();
     }
-    if (typeof initComparisonChart === 'function') {
-      initComparisonChart();
+    const tryInitComparison = () => {
+      if (typeof initComparisonChart === 'function') {
+        initComparisonChart();
+      }
+    };
+    if (document.readyState === 'complete') {
+      tryInitComparison();
+    } else {
+      window.addEventListener('load', tryInitComparison, { once: true });
     }
   });
 


### PR DESCRIPTION
## Summary
- initialize comparison chart on load via inline script
- log when `initComparisonChart` runs

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687b89cdc504832ca2de1071691be78f