### PR TITLE
Fix comparison chart visibility

### DIFF
--- a/front/public/comparison.js
+++ b/front/public/comparison.js
@@ -180,3 +180,21 @@ defs.append("marker")
   }
 }
 window.initComparisonChart = initComparisonChart;
+
+function initComparisonChartWhenReady() {
+  const el = document.getElementById('comparisonChart');
+  if (el) {
+    initComparisonChart();
+  } else {
+    const observer = new MutationObserver((_, obs) => {
+      const target = document.getElementById('comparisonChart');
+      if (target) {
+        obs.disconnect();
+        initComparisonChart();
+      }
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+  }
+}
+
+window.addEventListener('load', initComparisonChartWhenReady);

--- a/front/public/index.html
+++ b/front/public/index.html
@@ -23,15 +23,6 @@
         <script src="https://cdn.jsdelivr.net/npm/particles.js@2.0.0/particles.min.js"></script>
         <script src="https://cdn.jsdelivr.net/npm/@rdkit/rdkit@2025.3.2-1.0.0/dist/RDKit_minimal.js"></script>
 
-        <script>
-          window.addEventListener('load', () => {
-            if (typeof initComparisonChart === 'function') {
-              console.log('Initializing comparison chart');
-              initComparisonChart();
-            }
-          });
-        </script>
-
 
 </head>
 


### PR DESCRIPTION
## Summary
- add `initComparisonChartWhenReady` in `comparison.js`
- auto-start the chart when `#comparisonChart` appears
- remove inline loader script from `index.html`

## Testing
- `python -m py_compile back.py`

------
https://chatgpt.com/codex/tasks/task_e_687b8f7f74d0832c8dda9afc2677eae4