### PR TITLE
Show parent state in flow demo

### DIFF
--- a/front/public/Tetris.js
+++ b/front/public/Tetris.js
@@ -69,6 +69,8 @@ let candidateMoves = [];
 let topCandidates = [];
 let appliedArrows = [];
 let particles = [];
+// Track the previous board state so we can show it in the flow conservation demo
+let parentStateBoard = null;
 
 // Overlays for starting/restarting the game
 let startOverlay = null;
@@ -459,6 +461,10 @@ lock_piece() {
   // 2) Clear any full lines
   this.clear_lines();
 
+  // Capture the board before spawning a new piece so we can display it
+  // as the parent state in the flow conservation visualization
+  parentStateBoard = this.board.map(row => row.slice());
+
   // 3) Spawn the next piece and reset any cached info
   this.current_piece   = this.spawn_piece();
   this.target_piece    = null;
@@ -496,6 +502,9 @@ lock_piece() {
       }
     }
     this.clear_lines();
+    // Save board state before spawning a new piece so we can display the parent
+    // state in the flow conservation visualization
+    parentStateBoard = this.board.map(row => row.slice());
     this.current_piece = this.spawn_piece();
     this.target_piece = null;
     this.cached_moves = null;
@@ -1895,7 +1904,8 @@ function updateCandidateListUI() {
     initFlowConservationDemo({
       root:    { board: rootBoard },
       actions: actions,
-      results: results
+      results: results,
+      parents: parentStateBoard ? [{ board: parentStateBoard }] : []
     });
   }
 }

--- a/front/src/App.svelte
+++ b/front/src/App.svelte
@@ -1362,6 +1362,10 @@ The figure contrasts the behavior of a standard single-path reinforcement learne
       <svg id="flowConservationSVG" style="width:100%;height:auto;"></svg>
 
     </div>
+    <p class="section-text">
+      The flow conservation diagram also shows the parent state on the left,
+      with an arrow pointing to the current board.
+    </p>
 
     <section class="section">
       <h2 class="section-title">States and actions in Tetris</h2>


### PR DESCRIPTION
## Summary
- display the previous board state in the Tetris flow conservation visualization
- mention the parent board in the page text

## Testing
- `npm run build` *(fails: rollup not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bb14c97d0832c8aaaeb5dc87e650a