### PR TITLE
Fix parent board reset after game restart

### DIFF
--- a/front/public/Tetris.js
+++ b/front/public/Tetris.js
@@ -1752,6 +1752,9 @@ function doResetGame() {
     restartOverlay = null;
   }
   resetGameLogic();
+  // Reset the parent board so the flow conservation demo starts from
+  // an empty state after a restart
+  parentStateBoard = game.board.map(row => row.slice());
   // make sure a leftover inference doesn't block new scoring
   scoringInProgress = false;
 


### PR DESCRIPTION
## Summary
- ensure `parentStateBoard` is reinitialized when the game restarts

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_687bb5a18638832cb26e92180b06e4e1