### PR TITLE
Center screenshots

### DIFF
--- a/front/src/App.svelte
+++ b/front/src/App.svelte
@@ -1343,14 +1343,18 @@ The figure contrasts the behavior of a standard single-path reinforcement learne
       <p class="section-text">
         The current Tetris board layout, showing all settled tetrominoes. This captures both dangerous gaps and potential “almost complete” rows.
       </p>
-      <img src="/images/screenshot1.png" alt="Screenshot illustrating Tetris state" />
+      <div class="image-container">
+        <img class="image" src="/images/screenshot1.png" alt="Screenshot illustrating Tetris state" />
+      </div>
     </li>
     <li class="section-text">
       <strong class="section-text">Action</strong>
       <p class="section-text">
         Each legal drop of the incoming tetromino (all rotations and column positions). Performing an action transitions the board to a new configuration.
       </p>
-      <img src="/images/screenshot2.png" alt="Screenshot illustrating Tetris action" />
+      <div class="image-container">
+        <img class="image" src="/images/screenshot2.png" alt="Screenshot illustrating Tetris action" />
+      </div>
     </li>
     <li class="section-text">
       <strong class="section-text">Reward</strong>
@@ -1364,7 +1368,9 @@ The figure contrasts the behavior of a standard single-path reinforcement learne
   <p class="section-text">
     This diagram shows how the GFlowNet maintains flow through multiple board configurations at once, converging from different past states and branching toward diverse future placements.
   </p>
-  <img src="/images/screenshot3.png" alt="Full DAG illustration of Tetris configurations" />
+  <div class="image-container">
+    <img class="image" src="/images/screenshot3.png" alt="Full DAG illustration of Tetris configurations" />
+  </div>
 
   <h3 class="section-title3">From Flow to Sampling</h3>
   <p class="section-text">


### PR DESCRIPTION
## Summary
- center all screenshot images in App.svelte

## Testing
- `npm run build` *(fails: rollup not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d4372ff60832ca2afa327a23a68a3