### PR TITLE
Adjust screenshot sizes

### DIFF
--- a/front/src/App.svelte
+++ b/front/src/App.svelte
@@ -1343,8 +1343,8 @@ The figure contrasts the behavior of a standard single-path reinforcement learne
       <p class="section-text">
         The current Tetris board layout, showing all settled tetrominoes. This captures both dangerous gaps and potential “almost complete” rows.
       </p>
-      <div class="image-container">
-        <img class="image" src="/images/screenshot1.png" alt="Screenshot illustrating Tetris state" />
+      <div class="screenshot-container">
+        <img class="image screenshot-image" src="/images/screenshot1.png" alt="Screenshot illustrating Tetris state" />
       </div>
     </li>
     <li class="section-text">
@@ -1352,8 +1352,8 @@ The figure contrasts the behavior of a standard single-path reinforcement learne
       <p class="section-text">
         Each legal drop of the incoming tetromino (all rotations and column positions). Performing an action transitions the board to a new configuration.
       </p>
-      <div class="image-container">
-        <img class="image" src="/images/screenshot2.png" alt="Screenshot illustrating Tetris action" />
+      <div class="screenshot-container">
+        <img class="image screenshot-image" src="/images/screenshot2.png" alt="Screenshot illustrating Tetris action" />
       </div>
     </li>
     <li class="section-text">
@@ -1368,8 +1368,8 @@ The figure contrasts the behavior of a standard single-path reinforcement learne
   <p class="section-text">
     This diagram shows how the GFlowNet maintains flow through multiple board configurations at once, converging from different past states and branching toward diverse future placements.
   </p>
-  <div class="image-container">
-    <img class="image" src="/images/screenshot4.png" alt="Full DAG illustration of Tetris configurations" />
+  <div class="screenshot-container">
+    <img class="image screenshot-image" src="/images/screenshot4.png" alt="Full DAG illustration of Tetris configurations" />
   </div>
 
   <h3 class="section-title3">From Flow to Sampling</h3>

--- a/front/src/styles.css
+++ b/front/src/styles.css
@@ -119,12 +119,25 @@
       justify-content: center;
       margin: 0 auto 2rem;
   }
+  /* Smaller container used for tutorial screenshots */
+  .screenshot-container {
+    width: 400px;
+    display: flex;
+      justify-content: center;
+      margin: 0 auto 2rem;
+  }
 
   .image {
     max-width: 100%;
     width: 90%;
     border-radius: 8px;
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  }
+
+  /* Uniform sizing for screenshots */
+  .screenshot-image {
+    width: 100%;
+    max-width: 400px;
   }
 
 
@@ -145,6 +158,9 @@
     .image {
       width: 80%;
     }
+    .screenshot-container {
+      width: 90%;
+    }
   }
 
   @media (max-width: 480px) {
@@ -161,6 +177,9 @@
     }
 
     .image {
+      width: 100%;
+    }
+    .screenshot-container {
       width: 100%;
     }
   }


### PR DESCRIPTION
## Summary
- make screenshot containers smaller
- target screenshot images to max 400px width
- update tutorial to use new screenshot classes

## Testing
- `npm run build` *(fails: rollup not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d45f8f184832ca835c0c56803863c