### PR TITLE
Fix next state board position and disable parent flow

### DIFF
--- a/front/public/flow_conservation.js
+++ b/front/public/flow_conservation.js
@@ -102,7 +102,7 @@
       bhAct = rows * CS_ACT + PAD * 2;
     const xRoot = parents.length ? 200 : PAD,
       xAction = xRoot + 300,
-      xResult = W - bwRoot - PAD;
+      xResult = W - bwRoot - PAD - 40; // shift next state board left so it isn't cut
     const lanes = [H / 4, H / 2, (3 * H) / 4];
     const pLanes = parents.map((_, i) => ((i + 1) / (parents.length + 1)) * H);
 
@@ -233,9 +233,10 @@
     };
 
     window._spawnTimer = setInterval(spawn, SPAWN_INT);
-    if (parentPaths.length) {
-      window._spawnParentTimer = setInterval(spawnParent, SPAWN_INT);
-    }
+    // disable flow particles from parent state to board
+    // if (parentPaths.length) {
+    //   window._spawnParentTimer = setInterval(spawnParent, SPAWN_INT);
+    // }
 
     return {
       stop: () => {


### PR DESCRIPTION
## Summary
- shift the next state board 40px left in `flow_conservation.js`
- comment out spawning parent flow particles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e0281e8e4832c8ae4e1d9b18c6c0f