### PR TITLE
Rewrite Tetris fundamentals section

### DIFF
--- a/front/public/images/Tetris-action.svg
+++ b/front/public/images/Tetris-action.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#eee" />
+  <text x="50" y="50" font-size="10" text-anchor="middle" fill="#555">Action</text>
+</svg>

--- a/front/public/images/Tetris-reward.svg
+++ b/front/public/images/Tetris-reward.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#eee" />
+  <text x="50" y="50" font-size="10" text-anchor="middle" fill="#555">Reward</text>
+</svg>

--- a/front/public/images/Tetris-state.svg
+++ b/front/public/images/Tetris-state.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#eee" />
+  <text x="50" y="50" font-size="10" text-anchor="middle" fill="#555">State</text>
+</svg>

--- a/front/public/images/tetris-dag.svg
+++ b/front/public/images/tetris-dag.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#eee" />
+  <text x="50" y="50" font-size="10" text-anchor="middle" fill="#555">DAG</text>
+</svg>

--- a/front/src/App.svelte
+++ b/front/src/App.svelte
@@ -1311,63 +1311,90 @@ The figure contrasts the behavior of a standard single-path reinforcement learne
     GFlowNet Fundamentals Illustrated with Tetris
   </h2>
 
+  <p class="section-text">
+    To better understand the core concepts used by GFlowNets, let’s consider a
+    simplified version of the Tetris game. In traditional Tetris, players remove
+    filled lines to survive as long as possible. Here we ignore line clears so
+    the goal becomes filling the entire grid.
+  </p>
+  <p class="section-text">
+    GFlowNets sample trajectories iteratively by moving from one state to the
+    next via available actions. All state–action possibilities form a directed
+    acyclic graph (DAG) representing every way the game could unfold. Because the
+    action space is huge, we use this simplified Tetris setting to illustrate the
+    idea.
+  </p>
+
   <ul class="section-text">
     <!-- State -->
-    <li>
-      <strong>State</strong>
-      <p>
-        A state describes a partial or complete object under construction. In GFlowNets, every possible state is a node in a directed acyclic graph (DAG). Defining states tells the model where it is in the generative process and what options remain.
-      </p>
-      <p>
-        <em>In Tetris:</em> the current board layout, showing all settled tetrominoes. This captures both dangerous gaps and “almost complete” rows.
-      </p>
-      <div class="screenshot-container">
-        <img
-          class="image screenshot-image-small"
-          src="/images/screenshot5.png"
-          alt="Screenshot illustrating Tetris state"
-        />
+    <li class="tetris-row">
+      <div>
+        <strong>State</strong>
+        <p>
+          A state fully describes the environment at a given moment. In a GFlowNet
+          every state is a node in the DAG that captures the generative process and
+          implicitly encodes which actions are still available.
+        </p>
+        <p>
+          <em>In Tetris:</em> the state corresponds to the current board with all
+          placed tetrominoes.
+        </p>
       </div>
+      <img
+        class="tetris-image"
+        src="/images/Tetris-state.svg"
+        alt="Tetris board state illustration"
+      />
     </li>
 
     <!-- Action -->
-    <li>
-      <strong>Action</strong>
-      <p>
-        Actions are the legal operations that move you from one state to the next (the edges of the DAG). They specify how you build up your object—whether by placing a block on a pyramid, attaching an atom in a molecule, or dropping a Tetris piece.
-      </p>
-      <p>
-        <em>In Tetris:</em> each legal drop of the incoming tetromino (all rotations and column positions). Performing an action transitions the board to a new configuration.
-      </p>
-      <div class="screenshot-container">
-        <img
-          class="image screenshot-image"
-          src="/images/screenshot2.png"
-          alt="Screenshot illustrating Tetris action"
-        />
+    <li class="tetris-row">
+      <div>
+        <strong>Action</strong>
+        <p>
+          Actions transform one state into another and form the edges of the DAG.
+          They specify how the object under construction is extended step by step.
+        </p>
+        <p>
+          <em>In Tetris:</em> each legal drop of the falling tetromino—across all
+          rotations and column choices—constitutes a distinct action that yields a
+          new board configuration.
+        </p>
       </div>
+      <img
+        class="tetris-image"
+        src="/images/Tetris-action.svg"
+        alt="Tetris action illustration"
+      />
     </li>
 
     <!-- Reward -->
     <li>
       <strong>Reward</strong>
       <p>
-        In GFlowNets, the reward function is defined by the user to encode the task’s goal.
-        For the Tetris demo, the reward was set to the total number of tetrominoes placed on the board—
-        equivalently, the number of occupied cells at game end (with optional line-clear and survival bonuses).
-        When play finishes, the incoming flow into each terminal board configuration is set equal to this user-defined reward.
+        The reward function quantifies how desirable a state is for the task at
+        hand. In this simplified Tetris demo we use the number of occupied cells
+        once no further moves are possible as the final reward.
       </p>
+      <img
+        class="tetris-image"
+        src="/images/Tetris-reward.svg"
+        alt="Tetris reward illustration"
+      />
     </li>
   </ul>
 
   <p class="section-text">
-    This diagram shows how the GFlowNet maintains flow through multiple board configurations at once, converging from different past states and branching toward diverse future placements.
+    The sampling process takes place on an implicit DAG where flows indicate the
+    desirability of each transition. The illustration below shows a small part of
+    the Tetris DAG: state <em>t</em> can be reached from two different parents and
+    branches out to several future states.
   </p>
-  <div class="screenshot-container">
+  <div class="image-container-small">
     <img
-      class="image screenshot-image"
-      src="/images/screenshot4.png"
-      alt="Full DAG illustration of Tetris configurations"
+      class="tetris-image"
+      src="/images/tetris-dag.svg"
+      alt="Tetris DAG illustration"
     />
   </div>
 

--- a/front/src/styles.css
+++ b/front/src/styles.css
@@ -147,6 +147,20 @@
     max-height: 300px;
   }
 
+  /* Layout for Tetris concept illustrations */
+  .tetris-row {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+  }
+
+  .tetris-image {
+    width: 180px;
+    max-width: 40%;
+    flex-shrink: 0;
+  }
+
 
   @media (max-width: 768px) {
     .title {
@@ -166,6 +180,16 @@
     }
     .screenshot-container {
       width: 90%;
+    }
+
+    .tetris-row {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+
+    .tetris-image {
+      width: 100%;
+      max-width: 300px;
     }
   }
 
@@ -187,6 +211,10 @@
     }
     .screenshot-container {
       width: 100%;
+    }
+
+    .tetris-image {
+      max-width: 100%;
     }
   }
 


### PR DESCRIPTION
## Summary
- rewrite the `GFlowNet Fundamentals Illustrated with Tetris` section using new SVG images
- add styling for `tetris-row` layout and responsive images
- include placeholder SVG diagrams

## Testing
- `npm run build` *(fails: rollup not found)*

------
https://chatgpt.com/codex/tasks/task_e_68824e167958832caeb4abca28ebc68c